### PR TITLE
Reverse the order of the local netblocks

### DIFF
--- a/src/bin/mirrorlist-server.rs
+++ b/src/bin/mirrorlist-server.rs
@@ -813,6 +813,7 @@ fn do_mirrorlist(req: Request<Body>, p: &mut DoMirrorlist) -> Response<Body> {
     // Shuffle and order by prefix size
     netblock_results.shuffle(&mut thread_rng());
     netblock_results.sort_by_key(|k| IpNet::from_str(&k.0).unwrap().prefix_len());
+    netblock_results.reverse();
 
     for e in netblock_results {
         all_hosts.push(e.1);


### PR DESCRIPTION
The list of all possible local netblocks is unfortunately sorted from smallest netmask to largest which is exactly the wrong way.

A simple reverse of the local netblocks vector fixes this.