### PR TITLE
Remove support for Internet2 mirrors

### DIFF
--- a/src/bin/mirrorlist_server_test/mod.rs
+++ b/src/bin/mirrorlist_server_test/mod.rs
@@ -174,7 +174,6 @@ fn do_mirrorlist_test() {
         mirrorlist: &mirrorlist.clone(),
         remote: &remote,
         asn_cache: &asn_cache,
-        i2_cache: &asn_cache,
         geoip: &geoip_reader,
         cc: &cc,
         log_file: &log_file,


### PR DESCRIPTION
The data source for the Internet2 routing tables is not accessible any more and therefore we will no longer support Internet2 as an additional mirror selection criteria.