### PR TITLE
build: upgrade protobuf and protobuf-codegen crates to 3.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hyper = { version = "0.14", features = ["server", "http1", "http2", "runtime"] }
 log = "0.4"
 pretty_env_logger = "0.5"
 chrono = "0.4.40"
-protobuf = "3.7.1"
+protobuf = "3.7.2"
 url = "2.5.4"
 regex = "1"
 ipnet = "2.10.1"
@@ -35,7 +35,7 @@ version = "1.29.1"
 features = ["macros", "rt-multi-thread"]
 
 [build-dependencies]
-protobuf-codegen = "3.7.1"
+protobuf-codegen = "3.7.2"
 
 [dev-dependencies]
 tempfile = "3.10.1"


### PR DESCRIPTION
The protobuf and protobuf-codegen crates have been upgraded from version 3.7.1 to 3.7.2. This change updates the dependencies in both the Cargo.toml and Cargo.lock files to use the newer versions.