### PR TITLE
Update console dependency to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,19 +135,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.0",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
@@ -691,7 +678,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
- "console 0.16.0",
+ "console",
  "portable-atomic",
  "unicode-width 0.2.0",
  "unit-prefix",
@@ -837,7 +824,7 @@ name = "mirrorlist-server"
 version = "3.0.7"
 dependencies = [
  "chrono",
- "console 0.15.11",
+ "console",
  "diesel",
  "dns-lookup",
  "dotenv",
@@ -1584,15 +1571,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dotenv = "0.15.0"
 dns-lookup = "2.0.4"
 ipnetwork = "0.21.1"
 indicatif = "0.18.0"
-console = "0.15.11"
+console = "0.16.0"
 tracing = "0.1.41"
 socket2 = "0.5.8"
 


### PR DESCRIPTION
The only breaking change in [`console` 0.16.0](https://github.com/console-rs/console/releases/tag/0.16.0) is that crates that depend on `console` with `default-features = False` may need to explicitly enable the new `std` feature.