### PR TITLE
Fix netblock host lookup off-by-one and convert CI to bats

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,34 +13,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_DB: test_db
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_USER: test_user
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
 
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y protobuf-compiler postgresql-client
-    - name: Build
-      run: cargo build --verbose
-    - name: Run clippy
-      run: cargo clippy --all-targets --verbose -- -D warnings
-    - name: Check formatting
-      run: cargo fmt --check
-    - name: Prepare database
-      run: PGPASSWORD=test_password psql -h localhost -U test_user test_db < testdata/database-setup.sql
+        sudo apt-get install -y protobuf-compiler bats
     - name: Run tests
-      run: TEST_DATABASE_URL="postgresql://test_user:test_password@localhost/test_db" cargo test --verbose -- --test-threads=1
+      run: bats tests/test_cargo.bats

--- a/src/bin/mirrorlist-server.rs
+++ b/src/bin/mirrorlist-server.rs
@@ -513,7 +513,7 @@ fn do_mirrorlist(req: Request<Body>, p: &mut DoMirrorlist) -> Response<Body> {
             if net.contains(&client_ip) {
                 for id in &hnb.value {
                     // Check if the host actually caries the requested content
-                    if find_in_int_repeated_int_map(&cache.ByHostId, *id) > 0 {
+                    if find_in_int_repeated_int_map(&cache.ByHostId, *id) >= 0 {
                         netblock_results.push((String::from(&net.to_string()), *id));
                     }
                 }

--- a/src/bin/mirrorlist_server_test/mod.rs
+++ b/src/bin/mirrorlist_server_test/mod.rs
@@ -378,3 +378,111 @@ fn do_mirrorlist_test() {
     drop(log_file);
     dir.close().unwrap();
 }
+
+#[test]
+fn netblock_host_at_index_zero_test() {
+    // Regression test for off-by-one error:
+    // find_in_int_repeated_int_map() returns a 0-based index (-1 when not
+    // found). The old code used "> 0" which incorrectly excluded hosts
+    // found at index 0 in ByHostId from netblock results.
+    let mut mirrorlist = MirrorList::new();
+    let mut mlc: Vec<MirrorListCacheType> = Vec::new();
+    let mut ml1 = MirrorListCacheType::new();
+    ml1.set_directory("test/netblock/path".to_string());
+
+    // Host 42 is at index 0 in ByHostId — this is the case the bug missed
+    let mut by_hostid: Vec<IntRepeatedIntMap> = Vec::new();
+    let mut hcurl_id = IntRepeatedIntMap::new();
+    hcurl_id.key = Some(42);
+    hcurl_id.value = vec![421];
+    by_hostid.push(hcurl_id);
+
+    hcurl_id = IntRepeatedIntMap::new();
+    hcurl_id.key = Some(99);
+    hcurl_id.value = vec![991];
+    by_hostid.push(hcurl_id);
+
+    ml1.ByHostId = by_hostid;
+    mlc.push(ml1);
+    mirrorlist.MirrorListCache = mlc;
+
+    // Set up HostNetblockCache so that 10.0.0.0/8 maps to host 42
+    let mut hnb = StringRepeatedIntMap::new();
+    hnb.key = Some("10.0.0.0/8".to_string());
+    hnb.value = vec![42];
+    mirrorlist.HostNetblockCache = vec![hnb];
+
+    let mut hbc: Vec<IntIntMap> = Vec::new();
+    let mut hb = IntIntMap::new();
+    hb.set_key(42);
+    hb.set_value(100);
+    hbc.push(hb);
+    hb = IntIntMap::new();
+    hb.set_key(99);
+    hb.set_value(100);
+    hbc.push(hb);
+    mirrorlist.HostBandwidthCache = hbc;
+
+    let mut hcurl: Vec<IntStringMap> = Vec::new();
+    let mut hc_url = IntStringMap::new();
+    hc_url.set_key(421);
+    hc_url.set_value("http://mirror42.example.com/pub".to_string());
+    hcurl.push(hc_url);
+    hc_url = IntStringMap::new();
+    hc_url.set_key(991);
+    hc_url.set_value("http://mirror99.example.com/pub".to_string());
+    hcurl.push(hc_url);
+    mirrorlist.HCUrlCache = hcurl;
+
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("global");
+    let mut file = File::create(&file_path).unwrap();
+    // Use a different subnet so ASN lookup does not match 10.0.0.1
+    writeln!(file, "192.168.0.0/16 12345").unwrap();
+    file.flush().unwrap();
+
+    let asn_cache = create_ip_tree(file_path.to_str().unwrap());
+    let geoip_reader =
+        maxminddb::Reader::open_readfile("testdata/GeoIP2-Country-Test.mmdb").unwrap();
+    let cc: HashMap<String, String> = HashMap::new();
+    let log_file = File::create(dir.path().join("log")).unwrap();
+
+    // Client IP 10.0.0.1 is inside the 10.0.0.0/8 netblock
+    let remote = IpAddr::from_str("10.0.0.1").unwrap();
+
+    let mut p = DoMirrorlist {
+        mirrorlist: &mirrorlist,
+        remote: &remote,
+        asn_cache: &asn_cache,
+        geoip: &geoip_reader,
+        cc: &cc,
+        log_file: &log_file,
+        minimum: 1,
+    };
+
+    let mut request = Request::new(Body::empty());
+    *request.uri_mut() = "/mirrorlist?path=test/netblock/path&ip=10.0.0.1"
+        .parse()
+        .unwrap();
+    let response = do_mirrorlist(request, &mut p);
+    assert_eq!(response.status(), 200);
+    let body = Runtime::new()
+        .unwrap()
+        .block_on(read_response_body(response))
+        .unwrap();
+    // Host 42 (at ByHostId index 0) must appear via netblock preference
+    assert!(
+        body.contains("Using preferred netblock"),
+        "Expected netblock header but got: {}",
+        body
+    );
+    assert!(
+        body.contains("http://mirror42.example.com/pub/"),
+        "Expected host 42 URL in response but got: {}",
+        body
+    );
+
+    drop(file);
+    drop(log_file);
+    dir.close().unwrap();
+}

--- a/tests/test_cargo.bats
+++ b/tests/test_cargo.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+CONTAINER_NAME="mirrorlist-test-postgres"
+POSTGRES_PASSWORD="test_password"
+DB_NAME="test_db"
+DB_PORT=5432
+
+setup_file() {
+    # Start PostgreSQL container
+    podman run --detach \
+        --name "${CONTAINER_NAME}" \
+        --env POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+        --publish "${DB_PORT}:5432" \
+        registry.access.redhat.com/hi/postgresql:latest
+
+    # Wait for PostgreSQL to be ready
+    for i in $(seq 1 30); do
+        if podman exec "${CONTAINER_NAME}" pg_isready -U postgres 2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+
+    # Create database and load schema
+    podman exec "${CONTAINER_NAME}" createdb -U postgres "${DB_NAME}"
+    podman exec -i "${CONTAINER_NAME}" psql -U postgres -d "${DB_NAME}" \
+        < testdata/database-setup.sql
+}
+
+teardown_file() {
+    podman rm -f "${CONTAINER_NAME}" || true
+}
+
+@test "cargo build" {
+    cargo build --verbose
+}
+
+@test "cargo clippy" {
+    cargo clippy --all-targets --verbose -- -D warnings
+}
+
+@test "cargo fmt check" {
+    cargo fmt --check
+}
+
+@test "cargo test" {
+    TEST_DATABASE_URL="postgresql://postgres:${POSTGRES_PASSWORD}@localhost:${DB_PORT}/${DB_NAME}" \
+        cargo test --verbose -- --test-threads=1
+}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  - Fix an off-by-one error in netblock host lookup that caused mirrors found at index 0 in the `ByHostId` cache to be silently excluded from prioritized netblock results                                                                    
  - Add a regression test covering the index-0 case                                                                                                                                                                                           
  - Convert CI from GitHub Actions service containers to a bats test suite with podman-managed PostgreSQL                                                                                                                                     
                                                                                                                                                                                                                                              
  ## Netblock bug fix                                                                                                                                                                                                                         
                                                                                                                                                                                                                                              
  `find_in_int_repeated_int_map()` returns a 0-based index (`-1` when not found). The condition `> 0` incorrectly excluded hosts found at index 0 in `ByHostId`, causing netblock-preferred mirrors to be placed at the end of the mirror list instead of being prioritized.                                                                                                                                                                                                              
                                                                                                                                                                                                                                              
  The fix changes `> 0` to `>= 0` in `src/bin/mirrorlist-server.rs`.                                                                                                                                                                          
                                                                                                                                                                                                                                              
  A regression test (`netblock_host_at_index_zero_test`) sets up a host at index 0 in `ByHostId`, puts the client IP inside the host's netblock, and asserts that the response includes the `Using preferred netblock` header and the correct mirror URL.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                              
  Fixes: https://forge.fedoraproject.org/infra/tickets/issues/13293                                                                                                                                                                           
                                                                                                                                                                                                                                              
  ## CI conversion to bats                                                                                                                                                                                                                    
                                                                                                                                                                                                                                              
  The GitHub Actions workflow previously used a `services:` block to run a Docker Hub `postgres` container and had separate inline steps for build, clippy, fmt, database setup, and tests. This is replaced with a single bats test script   
  (`tests/test_cargo.bats`) that:                                                                                                                                                                                                             
                                                                                                                                                                                                                                              
  1. Starts a PostgreSQL container via podman using the Red Hat Hummingbird image (`registry.access.redhat.com/hi/postgresql:latest`)                                                                                                         
  2. Waits for readiness with `pg_isready`                                                                                                                                                                                                    
  3. Creates the test database and loads the schema                                                                                                                                                                                           
  4. Runs four tests: `cargo build`, `cargo clippy`, `cargo fmt --check`, and `cargo test`                                                                                                                                                    
  5. Tears down the container on completion                                                                                                                                                                                                   
                                                                                                                                                                                                                                              
  | Aspect | Before | After |                                                                                                                                                                                                                 
  |--------|--------|-------|                                                                                                                                                                                                                 
  | DB image | `postgres` (Docker Hub) | `registry.access.redhat.com/hi/postgresql:latest` |                                                                                                                                                  
  | Lifecycle | GHA `services:` block | bats `setup_file` / `teardown_file` |                                                                                                                                                                 
  | DB user | `test_user` | `postgres` (default superuser) |                                                                                                                                                                                  
  | Container runtime | docker (GHA default) | podman |                                                                                                                                                                                       
  | `postgresql-client` | Required for schema load | Not needed (uses `podman exec`) |                                                                                                                                                        
                                                                                           